### PR TITLE
Develop

### DIFF
--- a/Anomaly_Detection_Notebook.ipynb
+++ b/Anomaly_Detection_Notebook.ipynb
@@ -72,23 +72,6 @@
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "bc0de62b",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "import getpass\n",
-    "import os\n",
-    "\n",
-    "password = getpass.getpass('Enter user password:\\n')\n",
-    "command = 'sudo -S apt-get update'\n",
-    "os.popen(command, 'w').write(password+'\\n')\n",
-    "command = 'sudo -S apt-get install -y libgl1 libglib2.0-0'\n",
-    "os.popen(command, 'w').write(password+'\\n')"
-   ]
-  },
-  {
    "cell_type": "markdown",
    "id": "9e233e40-cb7f-4200-997c-ef659f679972",
    "metadata": {},
@@ -128,13 +111,16 @@
     "<a id=\"get-started\"></a> \n",
     "## Get Started\n",
     "\n",
-    "Define an environment variable that will store the workspace path, this can be an existing directory or one created specifically for this reference use case. \n",
+    "Define an environment variable that will store the workspace path, this can be an existing directory or one created specifically for this reference use case.\n",
+    "\n",
     "```\n",
     "export WORKSPACE=/path/to/workspace/directory\n",
     "```\n",
     "\n",
     "### Download the Workflow Repository\n",
+    "\n",
     "Create a working directory for the reference use case and clone the [Visual Quality Inspection Workflow](https://github.com/intel/visual-quality-inspection) repository into your working directory.\n",
+    "\n",
     "```\n",
     "mkdir -p $WORKSPACE && cd $WORKSPACE\n",
     "git clone https://github.com/intel/visual-quality-inspection\n",
@@ -142,51 +128,11 @@
     "```\n",
     "\n",
     "### Download the Transfer Learning Tool\n",
+    "\n",
     "```\n",
     "git submodule update --init --recursive\n",
     "export PYTHONPATH=$WORKSPACE/visual-quality-inspection/transfer-learning/\n",
     "```"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "56c0e9d1",
-   "metadata": {
-    "tags": []
-   },
-   "outputs": [],
-   "source": [
-    "!git submodule update --init --recursive"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "f105907a",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "%env PYTHONPATH=transfer-learning/\n",
-    "import os\n",
-    "print(os.environ[\"PYTHONPATH\"])"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "3c9dd440",
-   "metadata": {},
-   "source": [
-    "<a id=\"Ways-to-run-this-reference-use-case\"></a> \n",
-    "# Ways to run this reference use case\n",
-    "\n",
-    "This reference kit offers three options for running the fine-tuning and inference processes:\n",
-    "\n",
-    "- Docker\n",
-    "- Argo Workflows on K8s Using Helm\n",
-    "- [Bare Metal](#run-using-bare-metal)\n",
-    "\n",
-    "Details about Bare Metal method can be found below."
    ]
   },
   {
@@ -195,15 +141,33 @@
    "metadata": {},
    "source": [
     "<a id=\"run-using-bare-metal\"></a> \n",
-    "# Run Using Jupyter Lab\n",
+    "# Run Using Jupyter\n",
     "\n",
+    "#### 1 Set up conda\n",
     "\n",
-    "You need an environment with jupyter lab, nb_conda_kernels and ipykernel in order to run this notebook.\n",
+    "To learn more, please visit [install anaconda on Linux](https://docs.anaconda.com/free/anaconda/install/linux/).\n",
+    "\n",
+    "```bash\n",
+    "wget https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh\n",
+    "bash Miniconda3-latest-Linux-x86_64.sh\n",
     "```\n",
-    "conda create -n notebook_env jupyterlab nb_conda_kernels ipykernel -y\n",
-    "conda activate notebook_env\n",
+    "\n",
+    "#### 2 Create and activate conda environment\n",
+    "\n",
+    "To be able to run `Anomaly_Detection_Notebook.ipynb` a conda environment must be created:\n",
+    "\n",
+    "```bash\n",
+    "conda create -n ju_anomaly_detection  -c conda-forge jupyterlab nb_conda_kernels python=3.9 -y\n",
+    "conda activate ju_anomaly_detection\n",
+    "```\n",
+    "\n",
+    "Follow the steps in [Get Started](#get-started) section before continuing. Run the following command inside of the project root directory. `WORKSPACE` must be set in the same terminal that will run Jupyter Lab.\n",
+    "\n",
+    "```bash\n",
     "jupyter lab\n",
-    "```"
+    "```\n",
+    "\n",
+    "Open jupyter lab in a web browser, select `Anomaly_Detection_Notebook.ipynb` and select `conda env:ju_anomaly_detection` as the jupyter kernel. Now you can follow the notebook's instructions step by step."
    ]
   },
   {
@@ -211,49 +175,7 @@
    "id": "ab0e33d4-8990-446b-8617-61049d5a9003",
    "metadata": {},
    "source": [
-    "### 1. Create environment and install software packages\n",
-    "\n",
-    "**Opton 1: Using conda:**"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "3b58a043-e979-4626-84b5-b087a30fcbdc",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "conda create -n anomaly_det_refkit python=3.9 ipykernel -y"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "2b06a05e-f2ee-45f4-a9ee-d6bf9485f73e",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "import IPython\n",
-    "IPython.Application.instance().kernel.do_shutdown(True) #automatically restarts kernel"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "f11f9553",
-   "metadata": {},
-   "source": [
-    "NOTE: Restart kernel and wait some seconds, and change kernel to conda env:anomaly_det_refkit"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "80d359d1-df30-4311-a350-4e37726a9f0a",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# Verify anomaly_det_refkit environment is active\n",
-    "!conda env list"
+    "### 1. Install software packages"
    ]
   },
   {
@@ -266,61 +188,6 @@
    "outputs": [],
    "source": [
     "!pip install -r requirements.txt"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "9b445eb4",
-   "metadata": {},
-   "source": [
-    "**Option 2: Using virtualenv:**\n",
-    "\n",
-    "```\n",
-    "python3 -m venv anomaly_det_refkit\n",
-    "source anomaly_det_refkit/bin/activate\n",
-    "pip install -r requirements.txt\n",
-    "```"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "ff2fa260",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "!python3 -m venv anomaly_det_refkit  \n",
-    "!anomaly_det_refkit/bin/python3 -m pip install ipykernel\n",
-    "!anomaly_det_refkit/bin/python3 -m ipykernel install --user --name anomaly_det_refkit"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "9f3d4f23-2205-421b-a8b5-c9d9e2599a85",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "import IPython\n",
-    "IPython.Application.instance().kernel.do_shutdown(True) #automatically restarts kernel"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "07d8479d-bf70-4359-85bf-b2235aeff557",
-   "metadata": {},
-   "source": [
-    "**NOTE:** Restart kernel and wait some seconds, and change kernel to anomaly_det_refkit. "
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "324473fa-29d2-4d4b-a28e-9f443a549ab8",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "!anomaly_det_refkit/bin/pip install -r requirements.txt"
    ]
   },
   {
@@ -422,7 +289,6 @@
    },
    "outputs": [],
    "source": [
-    "%env PYTHONPATH=transfer-learning/\n",
     "!python anomaly_detection.py --config_file ./configs/finetuning.yaml"
    ]
   },
@@ -572,7 +438,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%env PYTHONPATH=transfer-learning/\n",
     "!python anomaly_detection.py --config_file ./configs/finetuning.yaml"
    ]
   },
@@ -614,7 +479,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%env PYTHONPATH=transfer-learning/\n",
     "!python anomaly_detection.py --config_file ./configs/finetuning.yaml"
    ]
   },

--- a/README.md
+++ b/README.md
@@ -1,72 +1,67 @@
 # Anomaly Detection: Visual Quality Inspection in the Industrial Domain
 
-## Introduction
 
-Manual anomaly detection is time and labor-intensive which limits its applicability on large volumes of data that are typical in industrial settings. Application of artificial intelligence and machine learning is transforming Industrial Internet of Things (IIoT) segments by enabling higher productivity, better insights, less downtime, and superior product quality.
+## Introduction
+Manual anomaly detection is time and labor-intensive which limits its applicability on large volumes of data that are typical in industrial settings. Application of artificial intelligence and machine learning is transforming Industrial Internet of Things (IIoT) segments by enabling higher productivity, better insights, less downtime, and superior product quality. 
 
 The goal of this anomaly detection reference use case is to provide AI-powered visual quality inspection on the high resolution input images by identifing rare, abnormal events such as defects in a part being manufactured on an industrial production line. Use this reference solution as-is on your dataset, curate it to your needs by fine-tuning the models and changing configurations to get improved performance, modify it to meet your productivity and performance goals by making use of the modular architecture and realize superior performance using the Intel optimized software packages and libraries for Intel hardware that are built into the solution.
+
 
 The goal of this anomaly detection reference use case is to provide AI-powered visual quality inspection on high resolution input images by identifying rare, abnormal events such as defects in a part being manufactured on an industrial production line. Use this reference solution as-is on your dataset, curate it to your needs by fine-tuning the models, change configurations to get improved performance, and modify it to meet your productivity and performance goals by making use of the modular architecture and realize superior performance using the Intel optimized software packages and libraries for Intel hardware that are built into the solution.
 
 ## **Table of Contents**
-
 - [Technical Overview](#technical-overview)
-  - [DataSet](#DataSet)
+    - [DataSet](#DataSet)
 - [Validated Hardware Details](#validated-hardware-details)
 - [Software Requirements](#software-requirements)
 - [How it Works?](#how-it-works)
 - [Get Started](#get-started)
-  - [Download the Workflow Repository](#Download-the-Workflow-Repository)
-  - [Download the Transfer Learning Tool](#Download-the-Transfer-Learning-Tool)
+    - [Download the Workflow Repository](#Download-the-Workflow-Repository)
+    - [Download the Transfer Learning Tool](#Download-the-Transfer-Learning-Tool)
 - [Ways to run this reference use case](#Ways-to-run-this-reference-use-case)
-  - [Run Using Docker](#run-using-docker)
-  - [Jupyter](#run-using-jupyter)
-  - [Run Using Argo Workflows on K8s using Helm](#run-using-argo-workflows-on-k8s-using-helm)
-  - [Run Using Bare Metal](#run-using-bare-metal)
+    - [Run Using Docker](#run-using-docker)
+    - [Jupyter](#run-using-jupyter)
+    - [Run Using Argo Workflows on K8s using Helm](#run-using-argo-workflows-on-k8s-using-helm)
+    - [Run Using Bare Metal](#run-using-bare-metal) 
 - [Expected Output](#expected-output)
 - [Summary and Next Steps](#summary-and-next-steps)
-  - [Adopt to your dataset](#adopt-to-your-dataset)
-  - [Adopt to your model](#adopt-to-your-model)
+    - [Adopt to your dataset](#adopt-to-your-dataset)
+    - [Adopt to your model](#adopt-to-your-model)
 - [Learn More](#learn-more)
 - [Support](#support)
 
 ## Solution Technical Overview
-
-Classic and modern anomaly detection techniques have certain challenges:
-
-- Feature engineering needs to be performed to extract representations from the raw data. Traditional ML techniques rely on hand-crafted features that may not always generalize well to other settings.
-- Classification techniques require labeled training data, which is challenging because anomalies are typically rare occurrences and obtaining it increases the data collection & annotation effort.
+Classic and modern anomaly detection techniques have certain challenges: 
+- Feature engineering needs to be performed to extract representations from the raw data. Traditional ML techniques rely on hand-crafted features that may not always generalize well to other settings. 
+- Classification techniques require labeled training data, which is challenging because anomalies are typically rare occurrences and obtaining it increases the data collection & annotation effort. 
 - Nature of anomalies can be arbitrary and unknown where failures or defects occur for a variety of unpredictable reasons, hence it may not be possible to predict the type of anomaly.
 
 To overcome these challenges and achieve state-of-the-art performance, we present an unsupervised, mixed method end-to-end fine-tuning & inference reference solution for anomaly detection where a model of normality is learned from defect-free data in an unsupervised manner, and deviations from the models are flagged as anomalies. This reference use case is accelerated by Intel optimized software and is built upon easy-to-use Intel Transfer Learning Tool APIs.
 
 ### DataSet
-
 [MVTec AD](https://www.mvtec.com/company/research/datasets/mvtec-ad) is a dataset for benchmarking anomaly detection methods focused on visual quality inspection in the industrial domain. It contains over 5000 high-resolution images divided into ten unique objects and five unique texture categories. Each category comprises a set of defect-free training images and a test set of images with various kinds of defects as well as defect-free images. There are 73 different types of anomalies in the form of defects or structural deviations present in these objects and textures.
 
 More information can be in the paper [MVTec AD – A Comprehensive Real-World Dataset for Unsupervised Anomaly Detection](https://www.mvtec.com/fileadmin/Redaktion/mvtec.com/company/research/datasets/mvtec_ad.pdf)
 
 ![Statistical_overview_of_the_MVTec_AD_dataset](assets/mvtec_dataset_characteristics.JPG)
 <br>
-_Table 1: Statistical overview of the MVTec AD dataset. For each category, the number of training and test images is given together with additional information about the defects present in the respective test images. [Source](https://www.mvtec.com/fileadmin/Redaktion/mvtec.com/company/research/datasets/mvtec_ad.pdf)_
+*Table 1:  Statistical overview of the MVTec AD dataset. For each category, the number of training and test images is given together with additional information about the defects present in the respective test images. [Source](https://www.mvtec.com/fileadmin/Redaktion/mvtec.com/company/research/datasets/mvtec_ad.pdf)*
+
 
 ## Validated Hardware Details
+There are workflow-specific hardware and software setup requirements depending on how the workflow is run. Bare metal development system and Docker image running locally have the same system requirements. 
 
-There are workflow-specific hardware and software setup requirements depending on how the workflow is run. Bare metal development system and Docker image running locally have the same system requirements.
 
 ### On premise
-
-| Recommended Hardware                                           | Precision         |
-| -------------------------------------------------------------- | ----------------- |
-| Intel® 4th Gen Xeon® Scalable Performance processors           | float32, bfloat16 |
-| Intel® 1st, 2nd, 3rd Gen Xeon® Scalable Performance processors | float32           |
+| Recommended Hardware         | Precision  |
+| ---------------------------- | ---------- |
+| Intel® 4th Gen Xeon® Scalable Performance processors| float32, bfloat16 |
+| Intel® 1st, 2nd, 3rd Gen Xeon® Scalable Performance processors| float32 |
 
 ### On cloud instance
-
 The reference architecture has been validated to run on AWS m6i.16xlarge instance that has Intel(R) Xeon(R) Platinum 8375C CPU @ 2.90GHz, 64 vCPU, 256 GiB memory, 30 GB SSD storage, Ubuntu 22.04.2 LTS. The instance was hosted under dedicated tenancy and requires atleast 30 GB storage to accomodate the code and dataset.
 
-## Software Requirements
-
+## Software Requirements 
 Linux OS (Ubuntu 20.04) is used in this reference solution. Make sure the following dependencies are installed.
 
 1. `sudo apt update`
@@ -76,34 +71,34 @@ Linux OS (Ubuntu 20.04) is used in this reference solution. Make sure the follow
 
 ## How It Works?
 
-This reference use case uses a deep learning based approach, named deep-feature modeling (DFM) and falls within the broader area of out-of-distribution (OOD) detection i.e. when a model sees an input that differs from its training data, it is marked as an anomaly. Learn more about the approach [here.](https://arxiv.org/pdf/1909.11786.pdf)
+This reference use case uses a deep learning based approach, named deep-feature modeling (DFM) and falls within the broader area of out-of-distribution (OOD) detection i.e. when a model sees an input that differs from its training data, it is marked as an anomaly. Learn more about the approach [here.](https://arxiv.org/pdf/1909.11786.pdf) 
 
 The use case provides 3 options for modeling of the vision subtask:
-
-- **Pre-trained backbone:** uses a deep network (ResNet-50v1.5 in this case) that has been pretrained on large visual datasets such as ImageNet
-- **SimSiam self-supervised learning:** is a contrastive learning method based on Siamese networks. It learns meaningful representation of dataset without using any labels. SimSiam requires a dataloader such that it can produce two different augmented images from one underlying image. The end goal is to train the network to produce same features for both images. It takes a ResNet model as the backbone and fine-tunes the model on the augmented dataset to get closer feature embeddings for the use case. Read more [here.](https://arxiv.org/pdf/2011.10566.pdf)
-- **Cut-Paste self-supervised learning:** is a contrastive learning method similar to SimSiam but differs in the augmentations used during training. It take a ResNet model as backbone and fine-tunes the model after applying a data augmentation strategy that cuts an image patch and pastes at a random location of a large image. This allows us to construct a high performance model for defect detection without presence of anomalous data. Read more [here.](https://arxiv.org/pdf/2104.04015.pdf)
+* **Pre-trained backbone:** uses a deep network (ResNet-50v1.5 in this case) that has been pretrained on large visual datasets such as ImageNet
+* **SimSiam self-supervised learning:** is a contrastive learning method based on Siamese networks. It learns meaningful representation of dataset without using any labels. SimSiam requires a dataloader such that it can produce two different augmented images from one underlying image. The end goal is to train the network to produce same features for both images. It takes a ResNet model as the backbone and fine-tunes the model on the augmented dataset to get closer feature embeddings for the use case. Read more [here.](https://arxiv.org/pdf/2011.10566.pdf)
+* **Cut-Paste self-supervised learning:** is a contrastive learning method similar to SimSiam but differs in the augmentations used during training. It take a ResNet model as backbone and fine-tunes the model after applying a data augmentation strategy that cuts an image patch and pastes at a random location of a large image. This allows us to construct a high performance model for defect detection without presence of anomalous data. Read more [here.](https://arxiv.org/pdf/2104.04015.pdf)
 
 ![visual_quality_inspection_pipeline](assets/visual_quality_inspection_pipeline.JPG)
-_Figure 1: Visual quality inspection pipeline. Above diagram is an example when using SimSiam self-supervised training._
+*Figure 1: Visual quality inspection pipeline. Above diagram is an example when using SimSiam self-supervised training.*
 
 Training stage only uses defect-free data. Images are loaded using a dataloader and shuffling, resizing & normalization processing is applied. Then one of the above stated transfer learning technique is used to fine-tune a model and extract discriminative features from an intermediate layer. A PCA kernel is trained over these features to reduce the dimension of the feature space while retaining 99% variance. This pre-processing of the intermediate features of a DNN is needed to prevent matrix singularities and rank deficiencies from arising.
 
 During inference, the feature from a test image is generated through the same network as before. We then run a PCA transform using the trained PCA kernel and apply inverse transform to recreate original features and generate a feature-reconstruction error score, which is the norm of the difference between the original feature vector and the pre-image of its corresponding reduced embedding. Any image with an anomaly will have a high error in reconstructing original features due to features being out of distribution from the defect-free training set and will be marked as anomaly. The effectiveness of these scores in distinguishing the good images from the anomalous images is assessed by plotting the ROC curve, which is a plot of the true positive rate (TPR) of the classifier against the false positive rate (FPR) as the classification score-threshold is varied. The AUROC metric summarizes this curve between 0 to 1, with 1 indicating perfect classification.
 
+
+
 **Architecture:**
 ![Visual_quality_inspection_layered_architecture](assets/Visual_quality_inspection_layered_architecture.JPG)
 
 ### Highlights of Visual Quality Inspection Reference Use Case
-
 - The use case is presented in a modular architecture. To improve productivity and reduce time-to-solution, transfer learning methods are made available through an independent workflow that seamlessly uses Intel Transfer Learning Tool APIs underneath and a config file allows the user to change parameters and settings without having to deep-dive and modify the code.
 - There is flexibility to select any pre-trained model and any intermediate layer for feature extraction.
 - The use case is enabled with Intel optimized foundational tools.
 
+
 ## Get Started
 
-Define an environment variable that will store the workspace path, this can be an existing directory or one created specifically for this reference use case.
-
+Define an environment variable that will store the workspace path, this can be an existing directory or one created specifically for this reference use case. 
 ```
 export WORKSPACE=/path/to/workspace/directory
 ```
@@ -111,7 +106,6 @@ export WORKSPACE=/path/to/workspace/directory
 ### Download the Workflow Repository
 
 Create a working directory for the reference use case and clone the [Visual Quality Inspection Workflow](https://github.com/intel/visual-quality-inspection) repository into your working directory.
-
 ```
 mkdir -p $WORKSPACE && cd $WORKSPACE
 git clone https://github.com/intel/visual-quality-inspection
@@ -119,14 +113,12 @@ cd $WORKSPACE/visual-quality-inspection
 ```
 
 ### Download the Transfer Learning Tool
-
 ```
 git submodule update --init --recursive
 export PYTHONPATH=$WORKSPACE/visual-quality-inspection/transfer-learning/
 ```
 
 ## Ways to run this reference use case
-
 This reference kit offers three options for running the fine-tuning and inference processes:
 
 - [Docker](#run-using-docker)
@@ -137,14 +129,14 @@ This reference kit offers three options for running the fine-tuning and inferenc
 Details about each of these methods can be found below. Keep in mind that each method must be executed in a separate environment from each other. If you run first Docker Compose and then bare metal, this will cause issues.
 
 ## Run Using Docker
-
 Follow these instructions to set up and run our provided Docker image. For running on bare metal, see the [bare metal](#run-using-bare-metal) instructions.
 
 ### 1. Set Up Docker Engine and Docker Compose
-
 You'll need to install Docker Engine on your development system. Note that while **Docker Engine** is free to use, **Docker Desktop** may require you to purchase a license. See the [Docker Engine Server installation instructions](https://docs.docker.com/engine/install/#server) for details.
 
+
 To build and run this workload inside a Docker Container, ensure you have Docker Compose installed on your machine. If you don't have this tool installed, consult the official [Docker Compose installation documentation](https://docs.docker.com/compose/install/linux/#install-the-plugin-manually).
+
 
 ```bash
 DOCKER_CONFIG=${DOCKER_CONFIG:-$HOME/.docker}
@@ -155,43 +147,39 @@ docker compose version
 ```
 
 ### 2. Install Workflow Packages and Intel Transfer Learning Toolkit
-
 Ensure you have completed steps in the [Get Started Section](#get-started).
 
 ### 3. Set Up Docker Image
-
 Build or Pull the provided docker image.
 
 ```bash
 cd $WORKSPACE/visual-quality-inspection/docker
 docker compose build
 ```
-
 OR
-
 ```bash
 docker pull intel/ai-workflows:pa-anomaly-detection
 docker pull intel/ai-workflows:pa-tlt-anomaly-detection
 ```
 
 ### 4. Preprocess Dataset with Docker Compose
-
 Prepare dataset for Anomaly Detection workflows and accept the legal agreement to use the Intel Dataset Downloader.
 
 ```bash
 mkdir -p $WORKSPACE/data && chmod 777 $WORKSPACE/data
 cd $WORKSPACE/visual-quality-inspection/docker
-USER_CONSENT=y docker compose run preprocess
+USER_CONSENT=y docker compose run preprocess 
 ```
 
-| Environment Variable Name | Default Value  | Description                      |
-| ------------------------- | -------------- | -------------------------------- | --------------------------------------------- |
-| DATASET_DIR               | `$PWD/../data` | Unpreprocessed dataset directory |
-| USER_CONSENT              | n/a            | Consent to legal agreement       | <!-- TCE: Please help me word this better --> |
+| Environment Variable Name | Default Value | Description |
+| --- | --- | --- |
+| DATASET_DIR | `$PWD/../data` | Unpreprocessed dataset directory |
+| USER_CONSENT | n/a | Consent to legal agreement | <!-- TCE: Please help me word this better -->
 
 ### 5. Run Pipeline with Docker Compose
 
 The Vision Finetuning container must complete successfully before the Evaluation container can begin. The Evaluation container uses the model and checkpoint files created by the vision fine-tuning container stored in the `${OUTPUT_DIR}` directory to complete the evaluation tasks.
+
 
 ```mermaid
 %%{init: {'theme': 'dark'}}%%
@@ -214,15 +202,14 @@ Run entire pipeline to view the logs of different running containers.
 docker compose run stock-evaluation &
 ```
 
-| Environment Variable Name | Default Value     | Description                                |
-| ------------------------- | ----------------- | ------------------------------------------ |
-| CONFIG                    | `eval`            | Config file name                           |
-| CONFIG_DIR                | `$PWD/../configs` | Anomaly Detection Configurations directory |
-| DATASET_DIR               | `$PWD/../data`    | Preprocessed dataset directory             |
-| OUTPUT_DIR                | `$PWD/../output`  | Logfile and Checkpoint output              |
+| Environment Variable Name | Default Value | Description |
+| --- | --- | --- |
+| CONFIG | `eval` | Config file name |
+| CONFIG_DIR | `$PWD/../configs` | Anomaly Detection Configurations directory |
+| DATASET_DIR | `$PWD/../data` | Preprocessed dataset directory |
+| OUTPUT_DIR | `$PWD/../output` | Logfile and Checkpoint output |
 
 #### View Logs
-
 Follow logs of each individual pipeline step using the commands below:
 
 ```bash
@@ -230,13 +217,11 @@ docker compose logs stock-tlt-fine-tuning -f
 ```
 
 To view inference logs
-
 ```bash
 fg
 ```
 
 ### 6. Run One Workflow with Docker Compose
-
 Create your own script and run your changes inside of the container or run the evaluation without waiting for fine-tuning.
 
 ```mermaid
@@ -257,19 +242,18 @@ Run using Docker Compose.
 docker compose run dev
 ```
 
-| Environment Variable Name | Default Value          | Description                                |
-| ------------------------- | ---------------------- | ------------------------------------------ |
-| CONFIG                    | `eval`                 | Config file name                           |
-| CONFIG_DIR                | `$PWD/../configs`      | Anomaly Detection Configurations directory |
-| DATASET_DIR               | `$PWD/../data`         | Preprocessed Dataset                       |
-| OUTPUT_DIR                | `$PWD/output`          | Logfile and Checkpoint output              |
-| SCRIPT                    | `anomaly_detection.py` | Name of Script                             |
+| Environment Variable Name | Default Value | Description |
+| --- | --- | --- |
+| CONFIG | `eval` | Config file name |
+| CONFIG_DIR | `$PWD/../configs` | Anomaly Detection Configurations directory |
+| DATASET_DIR | `$PWD/../data` | Preprocessed Dataset |
+| OUTPUT_DIR | `$PWD/output` | Logfile and Checkpoint output |
+| SCRIPT | `anomaly_detection.py` | Name of Script |
 
 #### Run Docker Image in an Interactive Environment
 
 If your environment requires a proxy to access the internet, export your
 development system's proxy settings to the docker environment:
-
 ```bash
 export DOCKER_RUN_ENVS="-e ftp_proxy=${ftp_proxy} \
   -e FTP_PROXY=${FTP_PROXY} -e http_proxy=${http_proxy} \
@@ -279,7 +263,7 @@ export DOCKER_RUN_ENVS="-e ftp_proxy=${ftp_proxy} \
   -e SOCKS_PROXY=${SOCKS_PROXY}"
 ```
 
-Run the workflow with the `docker run` command, as shown:
+Run the workflow with the ``docker run`` command, as shown:
 
 ```bash
 export CONFIG_DIR=$PWD/../configs
@@ -297,13 +281,11 @@ docker run -a stdout ${DOCKER_RUN_ENVS} \
 ```
 
 Run the command below for fine-tuning and inference:
-
 ```bash
 python /workspace/anomaly_detection.py --config_file /workspace/configs/finetuning.yaml
 ```
 
 ### 7. Clean Up Docker Containers
-
 Stop containers created by docker compose and remove them.
 
 ```bash
@@ -339,35 +321,25 @@ jupyter lab
 Open jupyter lab in a web browser, select `Anomaly_Detection_Notebook.ipynb` and select `conda env:anomaly_det_refkit` as the jupyter kernel. Now you can follow the notebook's instructions step by step.
 
 ## Run Using Argo Workflows on K8s Using Helm
-
 ### 1. Install Helm
-
 - Install [Helm](https://helm.sh/docs/intro/install/)
-
 ```bash
 curl -fsSL -o get_helm.sh https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 && \
 chmod 700 get_helm.sh && \
 ./get_helm.sh
 ```
-
 ### 2. Setting up K8s
-
 - Install [Argo Workflows](https://argoproj.github.io/argo-workflows/quick-start/) and [Argo CLI](https://github.com/argoproj/argo-workflows/releases)
 - Configure your [Artifact Repository](https://argoproj.github.io/argo-workflows/configure-artifact-repository/)
 - Ensure that your dataset and config files are present in your chosen artifact repository.
-
 ### 3. Install Workflow Template
-
 ```bash
 export NAMESPACE=argo
 helm install --namespace ${NAMESPACE} --set proxy=${http_proxy} anomaly-detection ./chart
 argo submit --from wftmpl/workspace --namespace=${NAMESPACE}
 ```
-
-### 4. View
-
+### 4. View 
 To view your workflow progress
-
 ```bash
 argo logs @latest -f
 ```
@@ -377,7 +349,6 @@ argo logs @latest -f
 ### 1. Create environment and install software packages
 
 Using conda:
-
 ```
 conda create -n anomaly_det_refkit python=3.9
 conda activate anomaly_det_refkit
@@ -385,7 +356,6 @@ pip install -r requirements.txt
 ```
 
 Using virtualenv:
-
 ```
 python3 -m venv anomaly_det_refkit
 source anomaly_det_refkit/bin/activate
@@ -395,7 +365,6 @@ pip install -r requirements.txt
 ### 2. Download the dataset
 
 Download the mvtec dataset using Intel Model Zoo Dataset Librarian
-
 ```
 pip install dataset-librarian
 mkdir $WORKSPACE/visual-quality-inspection/data
@@ -406,21 +375,19 @@ python -m dataset_librarian.dataset -n mvtec-ad --download --preprocess -d $WORK
 
 Select the parameters and configurations in the [finetuning.yaml](configs/README.md) file.
 
-NOTE:
+NOTE: 
 When using SimSiam self supervised training, download the Sim-Siam weights based on ResNet50 model and place under simsiam directory:
-
 ```
 mkdir $WORKSPACE/visual-quality-inspection/simsiam
 wget --directory-prefix=/simsiam/ https://dl.fbaipublicfiles.com/simsiam/models/100ep-256bs/pretrain/checkpoint_0099.pth.tar -o $WORKSPACE/visual-quality-inspection/simsiam/checkpoint_0099.pth.tar
 ```
 
-### 4. Running the end-to-end use case
+### 4. Running the end-to-end use case 
 
 Using Transfer Learning Tool based fine-tuning:
 
 In finetuning.yaml, set **'fine_tune'** flag to true. If you downloaded the data from [DataSet](#DataSet) **change ./data/ to ./mvtec_dataset/** and set the pretrained/simsiam/cutpaste settings accordingly.
 Change other settings as intended in finetuning.yaml to run different configurations.
-
 ```
 cd $WORKSPACE/visual-quality-inspection
 python anomaly_detection.py --config_file $WORKSPACE/visual-quality-inspection/configs/finetuning.yaml
@@ -449,21 +416,21 @@ python anomaly_detection.py --config_file $WORKSPACE/visual-quality-inspection/c
 |   ZIPPER   |          151           | 97.16 |    90.07     |
 +------------+------------------------+-------+--------------+
 ```
+*Above results are on single node Dual socket 4th Generation Intel Xeon Scalable 8480+ (codenamed: Sapphire Rapids) Processor. 56 cores per socket, Intel® Turbo Boost Technology enabled, Intel® Hyper-Threading Technology enabled, 1024 GB memory (16x64GB), Configured Memory speed=4800 MT/s, INTEL SSDSC2BA012T4, CentOS Linux 8, BIOS=EGSDCRB.86B.WD.64.2022.29.7.13.1329, CPU Governor=performance, intel-extension-for-pytorch v2.0.0, torch 2.0.0, scikit-learn-intelex v2023.1.1, pandas 2.0.1. Configuration: precision=bfloat16, batch size=32, features extracted from pretrained resnet50v1.50 model.*
 
-_Above results are on single node Dual socket 4th Generation Intel Xeon Scalable 8480+ (codenamed: Sapphire Rapids) Processor. 56 cores per socket, Intel® Turbo Boost Technology enabled, Intel® Hyper-Threading Technology enabled, 1024 GB memory (16x64GB), Configured Memory speed=4800 MT/s, INTEL SSDSC2BA012T4, CentOS Linux 8, BIOS=EGSDCRB.86B.WD.64.2022.29.7.13.1329, CPU Governor=performance, intel-extension-for-pytorch v2.0.0, torch 2.0.0, scikit-learn-intelex v2023.1.1, pandas 2.0.1. Configuration: precision=bfloat16, batch size=32, features extracted from pretrained resnet50v1.50 model._
+
 
 ## Summary and Next Steps
 
-- If you want to enable distributed training on k8s for your use case, please follow steps to apply that configuration mentioned here [Intel® Transfer Learning Tools](https://github.com/IntelAI/transfer-learning/docker/README.md#kubernetes) which provides insights into k8s operators and yml file creation.
+* If you want to enable distributed training on k8s for your use case, please follow steps to apply that configuration mentioned here [Intel® Transfer Learning Tools](https://github.com/IntelAI/transfer-learning/docker/README.md#kubernetes) which provides insights into k8s operators and yml file creation.
 
-- The reference use case above demonstrates an Anomaly Detection approach using deep feature extraction and out-of-distrabution detection. It uses a tunable, modular workflow for fine-tuning the model & extractingits features, both of which uses the Intel® Transfer Learning Tool underneath. For optimal performance on Intel architecture, the scripts are also enabled with Intel extension for PyTorch, Intel extension for scikit-learn and has an option to run bfloat16 on 4th Gen Intel Xeon scalable processors using Intel® Advanced Matrix Extensions (Intel® AMX).
+* The reference use case above demonstrates an Anomaly Detection approach using deep feature extraction and out-of-distrabution detection. It uses a tunable, modular workflow for fine-tuning the model & extractingits features, both of which uses the Intel® Transfer Learning Tool underneath. For optimal performance on Intel architecture, the scripts are also enabled with Intel extension for PyTorch, Intel extension for scikit-learn and has an option to run bfloat16 on 4th Gen Intel Xeon scalable processors using Intel® Advanced Matrix Extensions (Intel® AMX).
 
 ### How to customize this use case
-
 Tunable configurations and parameters are exposed using yaml config files allowing users to change model training hyperparameters, datatypes, paths, and dataset settings without having to modify or search through the code.
 
-#### Adopt to your dataset
 
+#### Adopt to your dataset
 This reference use case can be easily deployed on a different or customized dataset by simply arranging the images for training and testing in the following folder structure (Note that this approach only uses good images for training):
 
 ```mermaid
@@ -483,15 +450,14 @@ For example, to run it for a [Marble Surface Anomaly Detection dataset](https://
 #### Adopt to your model
 
 #### 1. Change to a different pre-trained model from Torchvision:
-
 Change the 'model/name' variable in $WORKSPACE/visual-quality-inspection/configs/finetuning.yaml to the intended model e.g.: resnet18
 
-For simsiam, download the Sim-Siam weights based on the new model and place it under the simsiam directory. If no pre-trained simsiam weights are available, fine-tuning will take time and have to be run for more epochs.
+For simsiam, download the Sim-Siam weights based on the new model and place it under the simsiam directory. If no pre-trained simsiam weights are available, fine-tuning will take time and have to be run for more epochs. 
 Change other settings as intended in config.yaml to run different configurations. Then run the application using:
-
 ```
 python anomaly_detection.py --config_file $WORKSPACE/visual-quality-inspection/configs/finetuning.yaml
 ```
+
 
 #### 2. Plug-in your own pre-trained customized model:
 
@@ -499,21 +465,18 @@ In finetuning.yaml, change 'fine_tune' flag to false and provide a custom model 
 Change other settings as intended in config.yaml to run different configurations.
 
 To test the custom model with the MVTec AD dataset, add the preprocess flag to the dataset.py script to generate CSV files under all classes required for data loading:
-
 ```
 python dataset.py -n mvtec-ad --download --preprocess -d ../../../
 ```
 
 Then run the application using:
-
 ```
 python anomaly_detection.py --config_file $WORKSPACE/visual-quality-inspection/configs/finetuning.yaml
 ```
 
+
 ## Learn More
-
 For more information or to read about other relevant workflow examples, see these guides and software resources:
-
 - [Intel® Transfer Learning Tool](https://github.com/IntelAI/transfer-learning)
 - [Anomaly Detection fine-tuning workflow using SimSiam and CutPaste techniques](https://github.com/IntelAI/transfer-learning/tree/main/workflows/vision_anomaly_detection)
 - [Intel® AI Analytics Toolkit (AI Kit)](https://www.intel.com/content/www/us/en/developer/tools/oneapi/ai-analytics-toolkit.html)
@@ -522,7 +485,6 @@ For more information or to read about other relevant workflow examples, see thes
 - [Intel® Neural Compressor](https://github.com/intel/neural-compressor)
 
 ## Support
-
 If you have any questions with this workflow, want help with troubleshooting, want to report a bug or submit enhancement requests, please submit a GitHub issue.
 
 ---

--- a/README.md
+++ b/README.md
@@ -1,66 +1,72 @@
 # Anomaly Detection: Visual Quality Inspection in the Industrial Domain
 
-
 ## Introduction
-Manual anomaly detection is time and labor-intensive which limits its applicability on large volumes of data that are typical in industrial settings. Application of artificial intelligence and machine learning is transforming Industrial Internet of Things (IIoT) segments by enabling higher productivity, better insights, less downtime, and superior product quality. 
+
+Manual anomaly detection is time and labor-intensive which limits its applicability on large volumes of data that are typical in industrial settings. Application of artificial intelligence and machine learning is transforming Industrial Internet of Things (IIoT) segments by enabling higher productivity, better insights, less downtime, and superior product quality.
 
 The goal of this anomaly detection reference use case is to provide AI-powered visual quality inspection on the high resolution input images by identifing rare, abnormal events such as defects in a part being manufactured on an industrial production line. Use this reference solution as-is on your dataset, curate it to your needs by fine-tuning the models and changing configurations to get improved performance, modify it to meet your productivity and performance goals by making use of the modular architecture and realize superior performance using the Intel optimized software packages and libraries for Intel hardware that are built into the solution.
-
 
 The goal of this anomaly detection reference use case is to provide AI-powered visual quality inspection on high resolution input images by identifying rare, abnormal events such as defects in a part being manufactured on an industrial production line. Use this reference solution as-is on your dataset, curate it to your needs by fine-tuning the models, change configurations to get improved performance, and modify it to meet your productivity and performance goals by making use of the modular architecture and realize superior performance using the Intel optimized software packages and libraries for Intel hardware that are built into the solution.
 
 ## **Table of Contents**
+
 - [Technical Overview](#technical-overview)
-    - [DataSet](#DataSet)
+  - [DataSet](#DataSet)
 - [Validated Hardware Details](#validated-hardware-details)
 - [Software Requirements](#software-requirements)
 - [How it Works?](#how-it-works)
 - [Get Started](#get-started)
-    - [Download the Workflow Repository](#Download-the-Workflow-Repository)
-    - [Download the Transfer Learning Tool](#Download-the-Transfer-Learning-Tool)
+  - [Download the Workflow Repository](#Download-the-Workflow-Repository)
+  - [Download the Transfer Learning Tool](#Download-the-Transfer-Learning-Tool)
 - [Ways to run this reference use case](#Ways-to-run-this-reference-use-case)
-    - [Run Using Docker](#run-using-docker)
-    - [Run Using Argo Workflows on K8s using Helm](#run-using-argo-workflows-on-k8s-using-helm)
-    - [Run Using Bare Metal](#run-using-bare-metal) 
+  - [Run Using Docker](#run-using-docker)
+  - [Run Using Jupyter](#run-using-jupiter)
+  - [Run Using Argo Workflows on K8s using Helm](#run-using-argo-workflows-on-k8s-using-helm)
+  - [Run Using Bare Metal](#run-using-bare-metal)
 - [Expected Output](#expected-output)
 - [Summary and Next Steps](#summary-and-next-steps)
-    - [Adopt to your dataset](#adopt-to-your-dataset)
-    - [Adopt to your model](#adopt-to-your-model)
+  - [Adopt to your dataset](#adopt-to-your-dataset)
+  - [Adopt to your model](#adopt-to-your-model)
 - [Learn More](#learn-more)
 - [Support](#support)
 
 ## Solution Technical Overview
-Classic and modern anomaly detection techniques have certain challenges: 
-- Feature engineering needs to be performed to extract representations from the raw data. Traditional ML techniques rely on hand-crafted features that may not always generalize well to other settings. 
-- Classification techniques require labeled training data, which is challenging because anomalies are typically rare occurrences and obtaining it increases the data collection & annotation effort. 
+
+Classic and modern anomaly detection techniques have certain challenges:
+
+- Feature engineering needs to be performed to extract representations from the raw data. Traditional ML techniques rely on hand-crafted features that may not always generalize well to other settings.
+- Classification techniques require labeled training data, which is challenging because anomalies are typically rare occurrences and obtaining it increases the data collection & annotation effort.
 - Nature of anomalies can be arbitrary and unknown where failures or defects occur for a variety of unpredictable reasons, hence it may not be possible to predict the type of anomaly.
 
 To overcome these challenges and achieve state-of-the-art performance, we present an unsupervised, mixed method end-to-end fine-tuning & inference reference solution for anomaly detection where a model of normality is learned from defect-free data in an unsupervised manner, and deviations from the models are flagged as anomalies. This reference use case is accelerated by Intel optimized software and is built upon easy-to-use Intel Transfer Learning Tool APIs.
 
 ### DataSet
+
 [MVTec AD](https://www.mvtec.com/company/research/datasets/mvtec-ad) is a dataset for benchmarking anomaly detection methods focused on visual quality inspection in the industrial domain. It contains over 5000 high-resolution images divided into ten unique objects and five unique texture categories. Each category comprises a set of defect-free training images and a test set of images with various kinds of defects as well as defect-free images. There are 73 different types of anomalies in the form of defects or structural deviations present in these objects and textures.
 
 More information can be in the paper [MVTec AD – A Comprehensive Real-World Dataset for Unsupervised Anomaly Detection](https://www.mvtec.com/fileadmin/Redaktion/mvtec.com/company/research/datasets/mvtec_ad.pdf)
 
 ![Statistical_overview_of_the_MVTec_AD_dataset](assets/mvtec_dataset_characteristics.JPG)
 <br>
-*Table 1:  Statistical overview of the MVTec AD dataset. For each category, the number of training and test images is given together with additional information about the defects present in the respective test images. [Source](https://www.mvtec.com/fileadmin/Redaktion/mvtec.com/company/research/datasets/mvtec_ad.pdf)*
-
+_Table 1: Statistical overview of the MVTec AD dataset. For each category, the number of training and test images is given together with additional information about the defects present in the respective test images. [Source](https://www.mvtec.com/fileadmin/Redaktion/mvtec.com/company/research/datasets/mvtec_ad.pdf)_
 
 ## Validated Hardware Details
-There are workflow-specific hardware and software setup requirements depending on how the workflow is run. Bare metal development system and Docker image running locally have the same system requirements. 
 
+There are workflow-specific hardware and software setup requirements depending on how the workflow is run. Bare metal development system and Docker image running locally have the same system requirements.
 
 ### On premise
-| Recommended Hardware         | Precision  |
-| ---------------------------- | ---------- |
-| Intel® 4th Gen Xeon® Scalable Performance processors| float32, bfloat16 |
-| Intel® 1st, 2nd, 3rd Gen Xeon® Scalable Performance processors| float32 |
+
+| Recommended Hardware                                           | Precision         |
+| -------------------------------------------------------------- | ----------------- |
+| Intel® 4th Gen Xeon® Scalable Performance processors           | float32, bfloat16 |
+| Intel® 1st, 2nd, 3rd Gen Xeon® Scalable Performance processors | float32           |
 
 ### On cloud instance
+
 The reference architecture has been validated to run on AWS m6i.16xlarge instance that has Intel(R) Xeon(R) Platinum 8375C CPU @ 2.90GHz, 64 vCPU, 256 GiB memory, 30 GB SSD storage, Ubuntu 22.04.2 LTS. The instance was hosted under dedicated tenancy and requires atleast 30 GB storage to accomodate the code and dataset.
 
-## Software Requirements 
+## Software Requirements
+
 Linux OS (Ubuntu 20.04) is used in this reference solution. Make sure the following dependencies are installed.
 
 1. `sudo apt update`
@@ -70,34 +76,34 @@ Linux OS (Ubuntu 20.04) is used in this reference solution. Make sure the follow
 
 ## How It Works?
 
-This reference use case uses a deep learning based approach, named deep-feature modeling (DFM) and falls within the broader area of out-of-distribution (OOD) detection i.e. when a model sees an input that differs from its training data, it is marked as an anomaly. Learn more about the approach [here.](https://arxiv.org/pdf/1909.11786.pdf) 
+This reference use case uses a deep learning based approach, named deep-feature modeling (DFM) and falls within the broader area of out-of-distribution (OOD) detection i.e. when a model sees an input that differs from its training data, it is marked as an anomaly. Learn more about the approach [here.](https://arxiv.org/pdf/1909.11786.pdf)
 
 The use case provides 3 options for modeling of the vision subtask:
-* **Pre-trained backbone:** uses a deep network (ResNet-50v1.5 in this case) that has been pretrained on large visual datasets such as ImageNet
-* **SimSiam self-supervised learning:** is a contrastive learning method based on Siamese networks. It learns meaningful representation of dataset without using any labels. SimSiam requires a dataloader such that it can produce two different augmented images from one underlying image. The end goal is to train the network to produce same features for both images. It takes a ResNet model as the backbone and fine-tunes the model on the augmented dataset to get closer feature embeddings for the use case. Read more [here.](https://arxiv.org/pdf/2011.10566.pdf)
-* **Cut-Paste self-supervised learning:** is a contrastive learning method similar to SimSiam but differs in the augmentations used during training. It take a ResNet model as backbone and fine-tunes the model after applying a data augmentation strategy that cuts an image patch and pastes at a random location of a large image. This allows us to construct a high performance model for defect detection without presence of anomalous data. Read more [here.](https://arxiv.org/pdf/2104.04015.pdf)
+
+- **Pre-trained backbone:** uses a deep network (ResNet-50v1.5 in this case) that has been pretrained on large visual datasets such as ImageNet
+- **SimSiam self-supervised learning:** is a contrastive learning method based on Siamese networks. It learns meaningful representation of dataset without using any labels. SimSiam requires a dataloader such that it can produce two different augmented images from one underlying image. The end goal is to train the network to produce same features for both images. It takes a ResNet model as the backbone and fine-tunes the model on the augmented dataset to get closer feature embeddings for the use case. Read more [here.](https://arxiv.org/pdf/2011.10566.pdf)
+- **Cut-Paste self-supervised learning:** is a contrastive learning method similar to SimSiam but differs in the augmentations used during training. It take a ResNet model as backbone and fine-tunes the model after applying a data augmentation strategy that cuts an image patch and pastes at a random location of a large image. This allows us to construct a high performance model for defect detection without presence of anomalous data. Read more [here.](https://arxiv.org/pdf/2104.04015.pdf)
 
 ![visual_quality_inspection_pipeline](assets/visual_quality_inspection_pipeline.JPG)
-*Figure 1: Visual quality inspection pipeline. Above diagram is an example when using SimSiam self-supervised training.*
+_Figure 1: Visual quality inspection pipeline. Above diagram is an example when using SimSiam self-supervised training._
 
 Training stage only uses defect-free data. Images are loaded using a dataloader and shuffling, resizing & normalization processing is applied. Then one of the above stated transfer learning technique is used to fine-tune a model and extract discriminative features from an intermediate layer. A PCA kernel is trained over these features to reduce the dimension of the feature space while retaining 99% variance. This pre-processing of the intermediate features of a DNN is needed to prevent matrix singularities and rank deficiencies from arising.
 
 During inference, the feature from a test image is generated through the same network as before. We then run a PCA transform using the trained PCA kernel and apply inverse transform to recreate original features and generate a feature-reconstruction error score, which is the norm of the difference between the original feature vector and the pre-image of its corresponding reduced embedding. Any image with an anomaly will have a high error in reconstructing original features due to features being out of distribution from the defect-free training set and will be marked as anomaly. The effectiveness of these scores in distinguishing the good images from the anomalous images is assessed by plotting the ROC curve, which is a plot of the true positive rate (TPR) of the classifier against the false positive rate (FPR) as the classification score-threshold is varied. The AUROC metric summarizes this curve between 0 to 1, with 1 indicating perfect classification.
 
-
-
 **Architecture:**
 ![Visual_quality_inspection_layered_architecture](assets/Visual_quality_inspection_layered_architecture.JPG)
 
 ### Highlights of Visual Quality Inspection Reference Use Case
+
 - The use case is presented in a modular architecture. To improve productivity and reduce time-to-solution, transfer learning methods are made available through an independent workflow that seamlessly uses Intel Transfer Learning Tool APIs underneath and a config file allows the user to change parameters and settings without having to deep-dive and modify the code.
 - There is flexibility to select any pre-trained model and any intermediate layer for feature extraction.
 - The use case is enabled with Intel optimized foundational tools.
 
-
 ## Get Started
 
-Define an environment variable that will store the workspace path, this can be an existing directory or one created specifically for this reference use case. 
+Define an environment variable that will store the workspace path, this can be an existing directory or one created specifically for this reference use case.
+
 ```
 export WORKSPACE=/path/to/workspace/directory
 ```
@@ -105,6 +111,7 @@ export WORKSPACE=/path/to/workspace/directory
 ### Download the Workflow Repository
 
 Create a working directory for the reference use case and clone the [Visual Quality Inspection Workflow](https://github.com/intel/visual-quality-inspection) repository into your working directory.
+
 ```
 mkdir -p $WORKSPACE && cd $WORKSPACE
 git clone https://github.com/intel/visual-quality-inspection
@@ -112,29 +119,32 @@ cd $WORKSPACE/visual-quality-inspection
 ```
 
 ### Download the Transfer Learning Tool
+
 ```
 git submodule update --init --recursive
 export PYTHONPATH=$WORKSPACE/visual-quality-inspection/transfer-learning/
 ```
 
 ## Ways to run this reference use case
+
 This reference kit offers three options for running the fine-tuning and inference processes:
 
 - [Docker](#run-using-docker)
+- [Jupyter](#run-using-jupyter)
 - [Argo Workflows on K8s Using Helm](#run-using-argo-workflows-on-k8s-using-helm)
 - [Bare Metal](#run-using-bare-metal)
 
 Details about each of these methods can be found below. Keep in mind that each method must be executed in a separate environment from each other. If you run first Docker Compose and then bare metal, this will cause issues.
 
 ## Run Using Docker
+
 Follow these instructions to set up and run our provided Docker image. For running on bare metal, see the [bare metal](#run-using-bare-metal) instructions.
 
 ### 1. Set Up Docker Engine and Docker Compose
+
 You'll need to install Docker Engine on your development system. Note that while **Docker Engine** is free to use, **Docker Desktop** may require you to purchase a license. See the [Docker Engine Server installation instructions](https://docs.docker.com/engine/install/#server) for details.
 
-
 To build and run this workload inside a Docker Container, ensure you have Docker Compose installed on your machine. If you don't have this tool installed, consult the official [Docker Compose installation documentation](https://docs.docker.com/compose/install/linux/#install-the-plugin-manually).
-
 
 ```bash
 DOCKER_CONFIG=${DOCKER_CONFIG:-$HOME/.docker}
@@ -145,39 +155,43 @@ docker compose version
 ```
 
 ### 2. Install Workflow Packages and Intel Transfer Learning Toolkit
+
 Ensure you have completed steps in the [Get Started Section](#get-started).
 
 ### 3. Set Up Docker Image
+
 Build or Pull the provided docker image.
 
 ```bash
 cd $WORKSPACE/visual-quality-inspection/docker
 docker compose build
 ```
+
 OR
+
 ```bash
 docker pull intel/ai-workflows:pa-anomaly-detection
 docker pull intel/ai-workflows:pa-tlt-anomaly-detection
 ```
 
 ### 4. Preprocess Dataset with Docker Compose
+
 Prepare dataset for Anomaly Detection workflows and accept the legal agreement to use the Intel Dataset Downloader.
 
 ```bash
 mkdir -p $WORKSPACE/data && chmod 777 $WORKSPACE/data
 cd $WORKSPACE/visual-quality-inspection/docker
-USER_CONSENT=y docker compose run preprocess 
+USER_CONSENT=y docker compose run preprocess
 ```
 
-| Environment Variable Name | Default Value | Description |
-| --- | --- | --- |
-| DATASET_DIR | `$PWD/../data` | Unpreprocessed dataset directory |
-| USER_CONSENT | n/a | Consent to legal agreement | <!-- TCE: Please help me word this better -->
+| Environment Variable Name | Default Value  | Description                      |
+| ------------------------- | -------------- | -------------------------------- | --------------------------------------------- |
+| DATASET_DIR               | `$PWD/../data` | Unpreprocessed dataset directory |
+| USER_CONSENT              | n/a            | Consent to legal agreement       | <!-- TCE: Please help me word this better --> |
 
 ### 5. Run Pipeline with Docker Compose
 
 The Vision Finetuning container must complete successfully before the Evaluation container can begin. The Evaluation container uses the model and checkpoint files created by the vision fine-tuning container stored in the `${OUTPUT_DIR}` directory to complete the evaluation tasks.
-
 
 ```mermaid
 %%{init: {'theme': 'dark'}}%%
@@ -200,14 +214,15 @@ Run entire pipeline to view the logs of different running containers.
 docker compose run stock-evaluation &
 ```
 
-| Environment Variable Name | Default Value | Description |
-| --- | --- | --- |
-| CONFIG | `eval` | Config file name |
-| CONFIG_DIR | `$PWD/../configs` | Anomaly Detection Configurations directory |
-| DATASET_DIR | `$PWD/../data` | Preprocessed dataset directory |
-| OUTPUT_DIR | `$PWD/../output` | Logfile and Checkpoint output |
+| Environment Variable Name | Default Value     | Description                                |
+| ------------------------- | ----------------- | ------------------------------------------ |
+| CONFIG                    | `eval`            | Config file name                           |
+| CONFIG_DIR                | `$PWD/../configs` | Anomaly Detection Configurations directory |
+| DATASET_DIR               | `$PWD/../data`    | Preprocessed dataset directory             |
+| OUTPUT_DIR                | `$PWD/../output`  | Logfile and Checkpoint output              |
 
 #### View Logs
+
 Follow logs of each individual pipeline step using the commands below:
 
 ```bash
@@ -215,11 +230,13 @@ docker compose logs stock-tlt-fine-tuning -f
 ```
 
 To view inference logs
+
 ```bash
 fg
 ```
 
 ### 6. Run One Workflow with Docker Compose
+
 Create your own script and run your changes inside of the container or run the evaluation without waiting for fine-tuning.
 
 ```mermaid
@@ -240,18 +257,19 @@ Run using Docker Compose.
 docker compose run dev
 ```
 
-| Environment Variable Name | Default Value | Description |
-| --- | --- | --- |
-| CONFIG | `eval` | Config file name |
-| CONFIG_DIR | `$PWD/../configs` | Anomaly Detection Configurations directory |
-| DATASET_DIR | `$PWD/../data` | Preprocessed Dataset |
-| OUTPUT_DIR | `$PWD/output` | Logfile and Checkpoint output |
-| SCRIPT | `anomaly_detection.py` | Name of Script |
+| Environment Variable Name | Default Value          | Description                                |
+| ------------------------- | ---------------------- | ------------------------------------------ |
+| CONFIG                    | `eval`                 | Config file name                           |
+| CONFIG_DIR                | `$PWD/../configs`      | Anomaly Detection Configurations directory |
+| DATASET_DIR               | `$PWD/../data`         | Preprocessed Dataset                       |
+| OUTPUT_DIR                | `$PWD/output`          | Logfile and Checkpoint output              |
+| SCRIPT                    | `anomaly_detection.py` | Name of Script                             |
 
 #### Run Docker Image in an Interactive Environment
 
 If your environment requires a proxy to access the internet, export your
 development system's proxy settings to the docker environment:
+
 ```bash
 export DOCKER_RUN_ENVS="-e ftp_proxy=${ftp_proxy} \
   -e FTP_PROXY=${FTP_PROXY} -e http_proxy=${http_proxy} \
@@ -261,7 +279,7 @@ export DOCKER_RUN_ENVS="-e ftp_proxy=${ftp_proxy} \
   -e SOCKS_PROXY=${SOCKS_PROXY}"
 ```
 
-Run the workflow with the ``docker run`` command, as shown:
+Run the workflow with the `docker run` command, as shown:
 
 ```bash
 export CONFIG_DIR=$PWD/../configs
@@ -279,37 +297,77 @@ docker run -a stdout ${DOCKER_RUN_ENVS} \
 ```
 
 Run the command below for fine-tuning and inference:
+
 ```bash
 python /workspace/anomaly_detection.py --config_file /workspace/configs/finetuning.yaml
 ```
 
 ### 7. Clean Up Docker Containers
+
 Stop containers created by docker compose and remove them.
 
 ```bash
 docker compose down
 ```
 
+### Run Using Jupyter
+
+#### 1 Set up conda
+
+To learn more, please visit [install anaconda on Linux](https://docs.anaconda.com/free/anaconda/install/linux/).
+
+```bash
+wget https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh
+bash Miniconda3-latest-Linux-x86_64.sh
+```
+
+#### 2 Create and activate conda environment
+
+To be able to run `Anomaly_Detection_Notebook.ipynb` a conda environment must be created:
+
+```bash
+conda create -n anomaly_det_refkit -c conda-forge jupyterlab nb_conda_kernels python=3.9 -y
+conda activate anomaly_det_refkit
+```
+
+Follow the steps in [Get Started](#get-started) section before continuing. Run the following command inside of the project root directory. `WORKSPACE` must be set in the same terminal that will run Jupyter Lab.
+
+```bash
+jupyter lab
+```
+
+Open jupyter lab in a web browser, select `Anomaly_Detection_Notebook.ipynb` and select `conda env:anomaly_det_refkit` as the jupyter kernel. Now you can follow the notebook's instructions step by step.
+
 ## Run Using Argo Workflows on K8s Using Helm
+
 ### 1. Install Helm
+
 - Install [Helm](https://helm.sh/docs/intro/install/)
+
 ```bash
 curl -fsSL -o get_helm.sh https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 && \
 chmod 700 get_helm.sh && \
 ./get_helm.sh
 ```
+
 ### 2. Setting up K8s
+
 - Install [Argo Workflows](https://argoproj.github.io/argo-workflows/quick-start/) and [Argo CLI](https://github.com/argoproj/argo-workflows/releases)
 - Configure your [Artifact Repository](https://argoproj.github.io/argo-workflows/configure-artifact-repository/)
 - Ensure that your dataset and config files are present in your chosen artifact repository.
+
 ### 3. Install Workflow Template
+
 ```bash
 export NAMESPACE=argo
 helm install --namespace ${NAMESPACE} --set proxy=${http_proxy} anomaly-detection ./chart
 argo submit --from wftmpl/workspace --namespace=${NAMESPACE}
 ```
-### 4. View 
+
+### 4. View
+
 To view your workflow progress
+
 ```bash
 argo logs @latest -f
 ```
@@ -319,6 +377,7 @@ argo logs @latest -f
 ### 1. Create environment and install software packages
 
 Using conda:
+
 ```
 conda create -n anomaly_det_refkit python=3.9
 conda activate anomaly_det_refkit
@@ -326,6 +385,7 @@ pip install -r requirements.txt
 ```
 
 Using virtualenv:
+
 ```
 python3 -m venv anomaly_det_refkit
 source anomaly_det_refkit/bin/activate
@@ -335,6 +395,7 @@ pip install -r requirements.txt
 ### 2. Download the dataset
 
 Download the mvtec dataset using Intel Model Zoo Dataset Librarian
+
 ```
 pip install dataset-librarian
 mkdir $WORKSPACE/visual-quality-inspection/data
@@ -345,19 +406,21 @@ python -m dataset_librarian.dataset -n mvtec-ad --download --preprocess -d $WORK
 
 Select the parameters and configurations in the [finetuning.yaml](configs/README.md) file.
 
-NOTE: 
+NOTE:
 When using SimSiam self supervised training, download the Sim-Siam weights based on ResNet50 model and place under simsiam directory:
+
 ```
 mkdir $WORKSPACE/visual-quality-inspection/simsiam
 wget --directory-prefix=/simsiam/ https://dl.fbaipublicfiles.com/simsiam/models/100ep-256bs/pretrain/checkpoint_0099.pth.tar -o $WORKSPACE/visual-quality-inspection/simsiam/checkpoint_0099.pth.tar
 ```
 
-### 4. Running the end-to-end use case 
+### 4. Running the end-to-end use case
 
 Using Transfer Learning Tool based fine-tuning:
 
 In finetuning.yaml, set **'fine_tune'** flag to true. If you downloaded the data from [DataSet](#DataSet) **change ./data/ to ./mvtec_dataset/** and set the pretrained/simsiam/cutpaste settings accordingly.
 Change other settings as intended in finetuning.yaml to run different configurations.
+
 ```
 cd $WORKSPACE/visual-quality-inspection
 python anomaly_detection.py --config_file $WORKSPACE/visual-quality-inspection/configs/finetuning.yaml
@@ -386,21 +449,21 @@ python anomaly_detection.py --config_file $WORKSPACE/visual-quality-inspection/c
 |   ZIPPER   |          151           | 97.16 |    90.07     |
 +------------+------------------------+-------+--------------+
 ```
-*Above results are on single node Dual socket 4th Generation Intel Xeon Scalable 8480+ (codenamed: Sapphire Rapids) Processor. 56 cores per socket, Intel® Turbo Boost Technology enabled, Intel® Hyper-Threading Technology enabled, 1024 GB memory (16x64GB), Configured Memory speed=4800 MT/s, INTEL SSDSC2BA012T4, CentOS Linux 8, BIOS=EGSDCRB.86B.WD.64.2022.29.7.13.1329, CPU Governor=performance, intel-extension-for-pytorch v2.0.0, torch 2.0.0, scikit-learn-intelex v2023.1.1, pandas 2.0.1. Configuration: precision=bfloat16, batch size=32, features extracted from pretrained resnet50v1.50 model.*
 
-
+_Above results are on single node Dual socket 4th Generation Intel Xeon Scalable 8480+ (codenamed: Sapphire Rapids) Processor. 56 cores per socket, Intel® Turbo Boost Technology enabled, Intel® Hyper-Threading Technology enabled, 1024 GB memory (16x64GB), Configured Memory speed=4800 MT/s, INTEL SSDSC2BA012T4, CentOS Linux 8, BIOS=EGSDCRB.86B.WD.64.2022.29.7.13.1329, CPU Governor=performance, intel-extension-for-pytorch v2.0.0, torch 2.0.0, scikit-learn-intelex v2023.1.1, pandas 2.0.1. Configuration: precision=bfloat16, batch size=32, features extracted from pretrained resnet50v1.50 model._
 
 ## Summary and Next Steps
 
-* If you want to enable distributed training on k8s for your use case, please follow steps to apply that configuration mentioned here [Intel® Transfer Learning Tools](https://github.com/IntelAI/transfer-learning/docker/README.md#kubernetes) which provides insights into k8s operators and yml file creation.
+- If you want to enable distributed training on k8s for your use case, please follow steps to apply that configuration mentioned here [Intel® Transfer Learning Tools](https://github.com/IntelAI/transfer-learning/docker/README.md#kubernetes) which provides insights into k8s operators and yml file creation.
 
-* The reference use case above demonstrates an Anomaly Detection approach using deep feature extraction and out-of-distrabution detection. It uses a tunable, modular workflow for fine-tuning the model & extractingits features, both of which uses the Intel® Transfer Learning Tool underneath. For optimal performance on Intel architecture, the scripts are also enabled with Intel extension for PyTorch, Intel extension for scikit-learn and has an option to run bfloat16 on 4th Gen Intel Xeon scalable processors using Intel® Advanced Matrix Extensions (Intel® AMX).
+- The reference use case above demonstrates an Anomaly Detection approach using deep feature extraction and out-of-distrabution detection. It uses a tunable, modular workflow for fine-tuning the model & extractingits features, both of which uses the Intel® Transfer Learning Tool underneath. For optimal performance on Intel architecture, the scripts are also enabled with Intel extension for PyTorch, Intel extension for scikit-learn and has an option to run bfloat16 on 4th Gen Intel Xeon scalable processors using Intel® Advanced Matrix Extensions (Intel® AMX).
 
 ### How to customize this use case
+
 Tunable configurations and parameters are exposed using yaml config files allowing users to change model training hyperparameters, datatypes, paths, and dataset settings without having to modify or search through the code.
 
-
 #### Adopt to your dataset
+
 This reference use case can be easily deployed on a different or customized dataset by simply arranging the images for training and testing in the following folder structure (Note that this approach only uses good images for training):
 
 ```mermaid
@@ -420,14 +483,15 @@ For example, to run it for a [Marble Surface Anomaly Detection dataset](https://
 #### Adopt to your model
 
 #### 1. Change to a different pre-trained model from Torchvision:
+
 Change the 'model/name' variable in $WORKSPACE/visual-quality-inspection/configs/finetuning.yaml to the intended model e.g.: resnet18
 
-For simsiam, download the Sim-Siam weights based on the new model and place it under the simsiam directory. If no pre-trained simsiam weights are available, fine-tuning will take time and have to be run for more epochs. 
+For simsiam, download the Sim-Siam weights based on the new model and place it under the simsiam directory. If no pre-trained simsiam weights are available, fine-tuning will take time and have to be run for more epochs.
 Change other settings as intended in config.yaml to run different configurations. Then run the application using:
+
 ```
 python anomaly_detection.py --config_file $WORKSPACE/visual-quality-inspection/configs/finetuning.yaml
 ```
-
 
 #### 2. Plug-in your own pre-trained customized model:
 
@@ -435,18 +499,21 @@ In finetuning.yaml, change 'fine_tune' flag to false and provide a custom model 
 Change other settings as intended in config.yaml to run different configurations.
 
 To test the custom model with the MVTec AD dataset, add the preprocess flag to the dataset.py script to generate CSV files under all classes required for data loading:
+
 ```
 python dataset.py -n mvtec-ad --download --preprocess -d ../../../
 ```
 
 Then run the application using:
+
 ```
 python anomaly_detection.py --config_file $WORKSPACE/visual-quality-inspection/configs/finetuning.yaml
 ```
 
-
 ## Learn More
+
 For more information or to read about other relevant workflow examples, see these guides and software resources:
+
 - [Intel® Transfer Learning Tool](https://github.com/IntelAI/transfer-learning)
 - [Anomaly Detection fine-tuning workflow using SimSiam and CutPaste techniques](https://github.com/IntelAI/transfer-learning/tree/main/workflows/vision_anomaly_detection)
 - [Intel® AI Analytics Toolkit (AI Kit)](https://www.intel.com/content/www/us/en/developer/tools/oneapi/ai-analytics-toolkit.html)
@@ -455,6 +522,7 @@ For more information or to read about other relevant workflow examples, see thes
 - [Intel® Neural Compressor](https://github.com/intel/neural-compressor)
 
 ## Support
+
 If you have any questions with this workflow, want help with troubleshooting, want to report a bug or submit enhancement requests, please submit a GitHub issue.
 
 ---

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ The goal of this anomaly detection reference use case is to provide AI-powered v
   - [Download the Transfer Learning Tool](#Download-the-Transfer-Learning-Tool)
 - [Ways to run this reference use case](#Ways-to-run-this-reference-use-case)
   - [Run Using Docker](#run-using-docker)
-  - [Run Using Jupyter](#run-using-jupiter)
+  - [Jupyter](#run-using-jupyter)
   - [Run Using Argo Workflows on K8s using Helm](#run-using-argo-workflows-on-k8s-using-helm)
   - [Run Using Bare Metal](#run-using-bare-metal)
 - [Expected Output](#expected-output)


### PR DESCRIPTION
Fixed:
- Link the sections to the jupyter notebook instead of the README.md
- Remove code cell for software requirements.
- Also have the command !git submodule update --init --recursive as a comment instead of a code cell.
- Remove the code cell of %env PYTHONPATH=transfer-learning/ (it is already done on the README and on latter code cells).
- Remove the section Ways to run this reference use case and on README.md add Jupyer Lab as another method to execute.
- Add Run Using Jupyter Lab section on the README.md
- Instead of 'Create environment and install software packages' inside the notebook, add it on the README.
- Have just one environment anomaly_det_refkit and ope


place, take a look @gera-aldama